### PR TITLE
Extend MaximiseWindow to handle calls outside UI threads

### DIFF
--- a/KpcUwpCore/Display/WindowManager.cs
+++ b/KpcUwpCore/Display/WindowManager.cs
@@ -6,6 +6,8 @@
  */
 
 
+using System;
+using System.Diagnostics;
 using Windows.Foundation;
 using Windows.Graphics.Display;
 using Windows.UI.ViewManagement;
@@ -17,6 +19,8 @@ namespace KanoComputing.Display {
 
         /// <summary>Gets the screen resolution in effective pixels (raw pixel 
         /// resolution with scaling applied).</summary>
+        /// <remarks>This function must be called on a thread that is associated
+        /// with a CoreWindow.</remarks>
         /// <returns>Windows.Foundation.Size with width and height</returns>
         public virtual Size GetEffectiveScreenSize() {
             DisplayInformation display = DisplayInformation.GetForCurrentView();
@@ -37,9 +41,18 @@ namespace KanoComputing.Display {
         /// <summary>Sets the window to be maximised and take up the entire screen
         /// while the taskbar remains visible. This is not fullscreen.</summary>
         /// <remarks>Calling this function only works for the next launch of the
-        /// app.</remarks>
+        /// app. Additionally, if this function is not called on a thread that is
+        /// associated with a CoreWindow, the fallback display size will be set
+        /// to Int16.MaxValue.</remarks>
         public void MaximiseWindow() {
-            Size windowSize = this.GetEffectiveScreenSize();
+            Size windowSize = new Size(Int16.MaxValue, Int16.MaxValue);
+
+            try {
+                windowSize = this.GetEffectiveScreenSize();
+            } catch (Exception e) {
+                Debug.WriteLine("WindowManager: MaximiseWindow: Caught " + e);
+            }
+
             this.SetWindowSize(windowSize);
         }
 

--- a/KpcUwpCore/KpcUwpCore.nuspec
+++ b/KpcUwpCore/KpcUwpCore.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>KanoComputing.KpcUwpCore</id>
-    <version>1.2.1</version>
+    <version>1.2.4</version>
     <title>Kano PC Core UWP Libraries</title>
     <authors>Kano Computing</authors>
     <owners>Kano Computing</owners>
@@ -28,6 +28,6 @@
       src="bin\$configuration$\*.xr.xml"
       target="lib\uap10.0.17763\KpcUwpCore\"/>
     <file src="Assets\icon.png" target="images\"/>
-    <file src="..\LICENSE" target="licenses\"/>
+    <file src="..\LICENS*" target="licenses\"/>
   </files>
 </package>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,11 @@
 trigger:
   - master
 
+pr:
+  branches:
+    include:
+      - '*'
+
 pool:
   vmImage: 'windows-latest'
 


### PR DESCRIPTION
Given the function works for the next launch of the app, one option
would be to call the function from a Preinstall or Update background
task.