### PR TITLE
Extend the Mandatory Update page with in-app updates

### DIFF
--- a/KpcUwpCore/AppUpdate/MandatoryUpdate.xaml
+++ b/KpcUwpCore/AppUpdate/MandatoryUpdate.xaml
@@ -19,54 +19,116 @@
     <StackPanel
         HorizontalAlignment="Center"
         VerticalAlignment="Center">
+
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup>
+                <VisualState x:Name="UpdateAvailable">
+                    <VisualState.Setters>
+                        <Setter
+                            Target="UpdateAvailablePanel.Visibility"
+                            Value="Visible"/>
+                        <Setter
+                            Target="UpdateInstallingPanel.Visibility"
+                            Value="Collapsed"/>
+                        <Setter
+                            Target="UpdateFailedPanel.Visibility"
+                            Value="Collapsed"/>
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="UpdateInstalling">
+                    <VisualState.Setters>
+                        <Setter
+                            Target="UpdateAvailablePanel.Visibility"
+                            Value="Collapsed"/>
+                        <Setter
+                            Target="UpdateInstallingPanel.Visibility"
+                            Value="Visible"/>
+                        <Setter
+                            Target="UpdateFailedPanel.Visibility"
+                            Value="Collapsed"/>
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="UpdateFailed">
+                    <VisualState.Setters>
+                        <Setter
+                            Target="UpdateAvailablePanel.Visibility"
+                            Value="Collapsed"/>
+                        <Setter
+                            Target="UpdateInstallingPanel.Visibility"
+                            Value="Collapsed"/>
+                        <Setter
+                            Target="UpdateFailedPanel.Visibility"
+                            Value="Visible"/>
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+
         <TextBlock
             x:Uid="MandatoryUpdateAvailableTitle"
-            FontWeight="Normal"
             FontSize="36"
+            FontWeight="Normal"
             HorizontalAlignment="Center"
             TextWrapping="WrapWholeWords"/>
-        <!-- This message changes depending on the PageState set. -->
-        <TextBlock
-            Name="MessageText"
-            x:Uid="MandatoryUpdateAvailableMessage"
-            FontSize="20"
-            Padding="15"
-            HorizontalAlignment="Center"
-            TextWrapping="WrapWholeWords"/>
-        <!-- Items in this panel are shown depending on the PageState set.
-             Also, its Height is set such that toggling elements does not
-             re-center everything vertically. -->
+
         <StackPanel
+            x:Name="UpdateAvailablePanel"
             HorizontalAlignment="Center"
-            Margin="0,32,0,0"
-            Height="100">
+            Margin="0,30,0,0">
+            <TextBlock
+                x:Uid="MandatoryUpdateAvailableMessage"
+                FontSize="20"
+                HorizontalAlignment="Center"
+                TextWrapping="WrapWholeWords"/>
             <Button
-                Name="UpdateButton"
                 x:Uid="GetUpdate"
+                Click="OnUpdateButtonClick"
                 FontSize="16"
                 HorizontalAlignment="Center"
-                Click="OnUpdateButtonClick"/>
+                Margin="0,40,0,0"/>
+        </StackPanel>
+
+        <StackPanel
+            x:Name="UpdateInstallingPanel"
+            HorizontalAlignment="Center"
+            Margin="0,30,0,0">
+            <TextBlock
+                x:Uid="MandatoryUpdateInstallingMessage"
+                FontSize="20"
+                HorizontalAlignment="Center"
+                TextWrapping="WrapWholeWords"/>
             <ProgressBar
-                Name="ProgressBar"
+                x:Name="ProgressBar"
+                HorizontalAlignment="Center"
                 Maximum="1"
-                Width="250"
-                HorizontalAlignment="Center"/>
+                Margin="0,50,0,0"
+                Width="250"/>
+        </StackPanel>
+
+        <StackPanel
+            x:Name="UpdateFailedPanel"
+            HorizontalAlignment="Center"
+            Margin="0,30,0,0">
+            <TextBlock
+                x:Uid="MandatoryUpdateFailedMessage"
+                FontSize="20"
+                HorizontalAlignment="Center"
+                TextWrapping="WrapWholeWords"/>
             <StackPanel
                 HorizontalAlignment="Center"
+                Margin="0,40,0,0"
                 Orientation="Horizontal">
                 <Button
-                    Name="StoreButton"
                     x:Uid="MicrosoftStore"
+                    Click="OnStoreButtonClick"
                     FontSize="16"
-                    HorizontalAlignment="Center"
-                    Click="OnStoreButtonClick"/>
+                    HorizontalAlignment="Center"/>
                 <Button
-                    Name="LaterButton"
                     x:Uid="TryLater"
-                    Margin="40,0,0,0"
+                    Click="OnLaterButtonClick"
                     FontSize="16"
                     HorizontalAlignment="Center"
-                    Click="OnLaterButtonClick"/>
+                    Margin="40,0,0,0"/>
             </StackPanel>
         </StackPanel>
     </StackPanel>

--- a/KpcUwpCore/AppUpdate/MandatoryUpdate.xaml
+++ b/KpcUwpCore/AppUpdate/MandatoryUpdate.xaml
@@ -25,17 +25,49 @@
             FontSize="36"
             HorizontalAlignment="Center"
             TextWrapping="WrapWholeWords"/>
+        <!-- This message changes depending on the PageState set. -->
         <TextBlock
+            Name="MessageText"
             x:Uid="MandatoryUpdateAvailableMessage"
             FontSize="20"
             Padding="15"
             HorizontalAlignment="Center"
             TextWrapping="WrapWholeWords"/>
-        <Button
-            x:Uid="GetUpdate"
+        <!-- Items in this panel are shown depending on the PageState set.
+             Also, its Height is set such that toggling elements does not
+             re-center everything vertically. -->
+        <StackPanel
             HorizontalAlignment="Center"
             Margin="0,32,0,0"
-            FontSize="16"
-            Click="OnUpdateButtonClick"/>
+            Height="100">
+            <Button
+                Name="UpdateButton"
+                x:Uid="GetUpdate"
+                FontSize="16"
+                HorizontalAlignment="Center"
+                Click="OnUpdateButtonClick"/>
+            <ProgressBar
+                Name="ProgressBar"
+                Maximum="1"
+                Width="250"
+                HorizontalAlignment="Center"/>
+            <StackPanel
+                HorizontalAlignment="Center"
+                Orientation="Horizontal">
+                <Button
+                    Name="StoreButton"
+                    x:Uid="MicrosoftStore"
+                    FontSize="16"
+                    HorizontalAlignment="Center"
+                    Click="OnStoreButtonClick"/>
+                <Button
+                    Name="LaterButton"
+                    x:Uid="TryLater"
+                    Margin="40,0,0,0"
+                    FontSize="16"
+                    HorizontalAlignment="Center"
+                    Click="OnLaterButtonClick"/>
+            </StackPanel>
+        </StackPanel>
     </StackPanel>
 </Page>

--- a/KpcUwpCore/AppUpdate/MandatoryUpdate.xaml.cs
+++ b/KpcUwpCore/AppUpdate/MandatoryUpdate.xaml.cs
@@ -7,27 +7,232 @@
 
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.Core;
+using Windows.ApplicationModel.Resources;
+using Windows.Foundation;
+using Windows.Services.Store;
 using Windows.System;
+using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
 
 
 namespace KanoComputing.AppUpdate {
 
     /// <summary>
-    /// This page informs users that the app requires a mandatory update
+    /// This page informs users that the app requires a mandatory update and
+    /// allows them to download and install it. The process starts as soon as
+    /// the page is loaded when automatic updates are enabled in the Store.
     /// </summary>
     public sealed partial class MandatoryUpdate : Page {
+
+        private enum PageState {
+            UpdateAvailable,
+            UpdateInstalling,
+            UpdateFailed
+        }
 
         public MandatoryUpdate() {
             this.InitializeComponent();
         }
 
+        protected override void OnNavigatedTo(NavigationEventArgs args) {
+            StoreContext storeContext = StoreContext.GetDefault();
+
+            // If automatic updates are enabled in Microsoft Store > Settings then
+            // start the process immediately. Otherwise, allow the user to start it.
+            if (storeContext.CanSilentlyDownloadStorePackageUpdates) {
+                _ = this.DoUpdateAsync();
+            } else {
+                this.SetPageState(PageState.UpdateAvailable);
+            }
+        }
+
         private async void OnUpdateButtonClick(object sender, RoutedEventArgs e) {
+            await this.DoUpdateAsync();
+        }
+
+        private async void OnStoreButtonClick(object sender, RoutedEventArgs e) {
             // Launch the Microsoft Store to the Downloads and Updates page.
             await Launcher.LaunchUriAsync(
                 new Uri("ms-windows-store://downloadsandupdates")
             );
+        }
+
+        private void OnLaterButtonClick(object sender, RoutedEventArgs e) {
+            CoreApplication.Exit();
+        }
+
+        /// <summary>
+        /// Change the visual representation of the page depending on its state
+        /// by hiding or updating the UI elements.
+        /// </summary>
+        /// TODO: Is there a fancy XAML way to express UI states and do away with this?
+        private void SetPageState(PageState state) {
+            ResourceLoader resources = CoreWindow.GetForCurrentThread() != null ?
+                ResourceLoader.GetForCurrentView("KpcUwpCore/Resources") :
+                ResourceLoader.GetForViewIndependentUse("KpcUwpCore/Resources");
+
+            switch (state) {
+                case PageState.UpdateAvailable: {
+                    this.MessageText.Text = resources.GetString("MandatoryUpdateAvailableMessage/Text");
+                    this.UpdateButton.Visibility = Visibility.Visible;
+                    this.ProgressBar.Visibility = Visibility.Collapsed;
+                    this.StoreButton.Visibility = Visibility.Collapsed;
+                    this.LaterButton.Visibility = Visibility.Collapsed;
+                    break;
+                }
+                case PageState.UpdateInstalling: {
+                    this.MessageText.Text = resources.GetString("MandatoryUpdateInstallingMessage/Text");
+                    this.UpdateButton.Visibility = Visibility.Collapsed;
+                    this.ProgressBar.Value = 0;
+                    this.ProgressBar.Visibility = Visibility.Visible;
+                    this.StoreButton.Visibility = Visibility.Collapsed;
+                    this.LaterButton.Visibility = Visibility.Collapsed;
+                    break;
+                }
+                case PageState.UpdateFailed: {
+                    this.MessageText.Text = resources.GetString("MandatoryUpdateFailedMessage/Text");
+                    this.UpdateButton.Visibility = Visibility.Collapsed;
+                    this.ProgressBar.Visibility = Visibility.Collapsed;
+                    this.StoreButton.Visibility = Visibility.Visible;
+                    this.LaterButton.Visibility = Visibility.Visible;
+                    break;
+                }
+                default: {
+                    Debug.WriteLine($"{this.GetType()}: SetPageState: Unhandled {state}");
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Start the update process and change the UI accordingly.
+        /// </summary>
+        private async Task DoUpdateAsync() {
+            this.SetPageState(PageState.UpdateInstalling);
+
+            StoreContext context = StoreContext.GetDefault();
+
+            IReadOnlyList<StorePackageUpdate> updates =
+                await context.GetAppAndOptionalStorePackageUpdatesAsync();
+            StorePackageUpdateResult result =
+                await this.DownloadAndInstallAllUpdatesAsync(context, updates);
+
+            await this.HandleUpdateResultAsync(updates, result);
+        }
+
+        /// <summary>
+        /// Downloads and installs package updates in separate steps.
+        /// </summary>
+        private async Task<StorePackageUpdateResult> DownloadAndInstallAllUpdatesAsync(
+                StoreContext storeContext, IReadOnlyList<StorePackageUpdate> updates) {
+
+            if (updates.Count <= 0) {
+                Debug.WriteLine($"{this.GetType()}: DownloadAndInstallAllUpdatesAsync: No updates available");
+                return null;
+            }
+
+            foreach (var update in updates) {
+                Debug.WriteLine($"{this.GetType()}: DownloadAndInstallAllUpdatesAsync: Update for " +
+                    $"{update.Package.Id.FamilyName} to version {update.Package.Id.Version.Major}." +
+                    $"{update.Package.Id.Version.Minor}.{update.Package.Id.Version.Build}." +
+                    $"{update.Package.Id.Version.Revision} available");
+            }
+
+            // Download and install the updates and attempt to avoid
+            // asking the user for further confirmation.
+            IAsyncOperationWithProgress<StorePackageUpdateResult, StorePackageUpdateStatus> updateOperation;
+            updateOperation = storeContext.CanSilentlyDownloadStorePackageUpdates ?
+                storeContext.TrySilentDownloadAndInstallStorePackageUpdatesAsync(updates) :
+                storeContext.RequestDownloadAndInstallStorePackageUpdatesAsync(updates);
+
+            // The Progress async method is called one time for each step in the download
+            // and installation process for each package in this request.
+            updateOperation.Progress = async (asyncInfo, progress) => {
+                await this.Dispatcher.RunAsync(CoreDispatcherPriority.Normal,
+                () => {
+                    Debug.WriteLine($"{this.GetType()}: DownloadAndInstallAllUpdatesAsync: Updating " +
+                        $"{progress.PackageFamilyName}, progress {progress.PackageDownloadProgress}");
+                    this.ProgressBar.Value = progress.PackageDownloadProgress;
+                });
+            };
+
+            StorePackageUpdateResult result = await updateOperation.AsTask();
+
+            // UX: Wait for progress bar to stabilise.
+            await Task.Delay(500);
+            return result;
+        }
+
+        /// <summary>
+        /// Handle the result of the update process and update the UI accordingly.
+        /// </summary>
+        private async Task HandleUpdateResultAsync(
+                IReadOnlyList<StorePackageUpdate> updates, StorePackageUpdateResult result) {
+
+            if (result == null) {
+                this.SetPageState(PageState.UpdateFailed);
+                return;
+            }
+
+            switch (result.OverallState) {
+                // When the app has updated successfully, attempt to restart it,
+                // or show a notification to user and exit.
+                case StorePackageUpdateState.Completed: {
+                    Debug.WriteLine($"{this.GetType()}: HandleUpdateResultAsync: Update successful");
+                    if (!await this.RestartAppAsync()) {
+                        // We expect the Microsoft Store to show a notification that
+                        // the app was updated.
+                        CoreApplication.Exit();
+                    }
+                    break;
+                }
+                // If the update was cancelled by the user, allow them to try again.
+                case StorePackageUpdateState.Canceled: {
+                    Debug.WriteLine($"{this.GetType()}: HandleUpdateResultAsync: Update cancelled");
+                    this.SetPageState(PageState.UpdateAvailable);
+                    break;
+                }
+                // When the update failed for whatever reason, indicate this to
+                // the user and what to do next.
+                default: {
+                    Debug.WriteLine($"{this.GetType()}: HandleUpdateResultAsync: " +
+                        $"Update failed {result.OverallState}");
+                    this.SetPageState(PageState.UpdateFailed);
+
+                    IEnumerable<StorePackageUpdateStatus> failedUpdates =
+                        result.StorePackageUpdateStatuses.Where(
+                            status => status.PackageUpdateState != StorePackageUpdateState.Completed);
+
+                    foreach (StorePackageUpdateStatus failedUpdate in failedUpdates) {
+                        Debug.WriteLine($"{this.GetType()}: HandleUpdateResultAsync: " +
+                            $"{failedUpdate.PackageFamilyName} state is {failedUpdate.PackageUpdateState}");
+                    }
+                    if (updates.Any(u => u.Mandatory && failedUpdates.Any(
+                        failed => failed.PackageFamilyName == u.Package.Id.FamilyName))) {
+
+                        Debug.WriteLine($"{this.GetType()}: HandleUpdateResultAsync: " +
+                            $"Mandatory updates remaining");
+                    }
+                    break;
+                }
+            }
+        }
+
+        private async Task<bool> RestartAppAsync(string appArgs = "") {
+            AppRestartFailureReason result = await CoreApplication.RequestRestartAsync(appArgs);
+
+            // When successful, execution stops above and the app closes.
+            // Anything below gets executed when the request failed.
+
+            Debug.WriteLine($"{this.GetType()}: RestartAppAsync: Result was {result}");
+            return false;
         }
     }
 }

--- a/KpcUwpCore/Assets/Strings/en-US/Resources.resw
+++ b/KpcUwpCore/Assets/Strings/en-US/Resources.resw
@@ -117,32 +117,48 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="CheckConnection.Content" xml:space="preserve">
+  <data name="CheckConnection/Content" xml:space="preserve">
     <value>Check connection</value>
     <comment>This button launches the Windows Settings app to the page that helps users connect to the Internet.</comment>
   </data>
-  <data name="GetUpdate.Content" xml:space="preserve">
+  <data name="GetUpdate/Content" xml:space="preserve">
     <value>Get update</value>
-    <comment>This button launches the Microsoft Store to get updates for the app</comment>
+    <comment>This button starts the process of downloading and installing updates for the app.</comment>
   </data>
-  <data name="MandatoryUpdateAvailableMessage.Text" xml:space="preserve">
+  <data name="MandatoryUpdateAvailableMessage/Text" xml:space="preserve">
     <value>A mandatory update is available for your app. Update now to continue using it.</value>
-    <comment>Message informing users that they have to update the app in order to continue using it</comment>
+    <comment>Message informing users that they have to update the app in order to continue using it.</comment>
   </data>
-  <data name="MandatoryUpdateAvailableTitle.Text" xml:space="preserve">
+  <data name="MandatoryUpdateAvailableTitle/Text" xml:space="preserve">
     <value>Update available</value>
-    <comment>Title of the mandatory update available message being shown</comment>
+    <comment>Title of the mandatory update available message being shown.</comment>
   </data>
-  <data name="NoInternetConnectionMessage.Text" xml:space="preserve">
+  <data name="MandatoryUpdateFailedMessage/Text" xml:space="preserve">
+    <value>The update has failed to download and install this time. You can try again via the Store or later by starting the app.</value>
+    <comment>Message informing users that the app failed to update and that they have a couple of options.</comment>
+  </data>
+  <data name="MandatoryUpdateInstallingMessage/Text" xml:space="preserve">
+    <value>Updates for the app are now downloading and installing. This should only take a few minutes.</value>
+    <comment>Message informing users that the app is currently updating and should finish shortly.</comment>
+  </data>
+  <data name="MicrosoftStore/Content" xml:space="preserve">
+    <value>Update via Microsoft Store</value>
+    <comment>When updates fail to install, this button is shown to launch the Microsoft Store and retry the update.</comment>
+  </data>
+  <data name="NoInternetConnectionMessage/Text" xml:space="preserve">
     <value>The app can't open because you are not connected to the internet. Make sure Wi-Fi is on and try again.</value>
     <comment>Message informing users that they have to connect to the internet in order to continue using the app.</comment>
   </data>
-  <data name="NoInternetConnectionTitle.Text" xml:space="preserve">
+  <data name="NoInternetConnectionTitle/Text" xml:space="preserve">
     <value>Check your connection</value>
     <comment>Title of the no internet connection message being shown.</comment>
   </data>
-  <data name="Refresh.Content" xml:space="preserve">
+  <data name="Refresh/Content" xml:space="preserve">
     <value>Refresh</value>
     <comment>This button refreshes the web page potentially after the user connected to the Internet.</comment>
+  </data>
+  <data name="TryLater/Content" xml:space="preserve">
+    <value>Try again later</value>
+    <comment>When updates fail to install, this button is shown for the user to acknowledge that they can try to install the update later from the app. Once clicked, the app will close.</comment>
   </data>
 </root>

--- a/KpcUwpCore/Assets/Strings/en-US/Resources.resw
+++ b/KpcUwpCore/Assets/Strings/en-US/Resources.resw
@@ -134,11 +134,11 @@
     <comment>Title of the mandatory update available message being shown.</comment>
   </data>
   <data name="MandatoryUpdateFailedMessage/Text" xml:space="preserve">
-    <value>The update has failed to download and install this time. You can try again via the Store or later by starting the app.</value>
+    <value>The update was unable to complete. Please try again later by restarting the app or via the Store.</value>
     <comment>Message informing users that the app failed to update and that they have a couple of options.</comment>
   </data>
   <data name="MandatoryUpdateInstallingMessage/Text" xml:space="preserve">
-    <value>Updates for the app are now downloading and installing. This should only take a few minutes.</value>
+    <value>Downloading and installing updates. Please don't close the app. This should only take a few minutes.</value>
     <comment>Message informing users that the app is currently updating and should finish shortly.</comment>
   </data>
   <data name="MicrosoftStore/Content" xml:space="preserve">

--- a/KpcUwpCore/Assets/Strings/ja-JP/Resources.resw
+++ b/KpcUwpCore/Assets/Strings/ja-JP/Resources.resw
@@ -12,31 +12,31 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="GetUpdate.Content" xml:space="preserve">
+  <data name="GetUpdate/Content" xml:space="preserve">
     <value>アップデートする</value>
-    <comment>This button launches the Microsoft Store to get updates for the app</comment>
+    <comment>This button starts the process of downloading and installing updates for the app.</comment>
   </data>
-  <data name="MandatoryUpdateAvailableMessage.Text" xml:space="preserve">
+  <data name="MandatoryUpdateAvailableMessage/Text" xml:space="preserve">
     <value>必須のアップデートがあります。アプリを使い続けるにはいますぐアップデートしてください。</value>
-    <comment>Message informing users that they have to update the app in order to continue using it</comment>
+    <comment>Message informing users that they have to update the app in order to continue using it.</comment>
   </data>
-  <data name="MandatoryUpdateAvailableTitle.Text" xml:space="preserve">
+  <data name="MandatoryUpdateAvailableTitle/Text" xml:space="preserve">
     <value>アップデートの準備ができています</value>
-    <comment>Title of the mandatory update available message being shown</comment>
+    <comment>Title of the mandatory update available message being shown.</comment>
   </data>
-  <data name="CheckConnection.Content" xml:space="preserve">
+  <data name="CheckConnection/Content" xml:space="preserve">
     <value>接続を確認する</value>
     <comment>This button launches the Windows Settings app to the page that helps users connect to the Internet.</comment>
   </data>
-  <data name="NoInternetConnectionMessage.Text" xml:space="preserve">
+  <data name="NoInternetConnectionMessage/Text" xml:space="preserve">
     <value>インターネットに接続していないため、アプリを開くことができません。 Wi-Fiがオンになっていることを確認して、もう一度お試しください。</value>
     <comment>Message informing users that they have to connect to the internet in order to continue using the app.</comment>
   </data>
-  <data name="NoInternetConnectionTitle.Text" xml:space="preserve">
+  <data name="NoInternetConnectionTitle/Text" xml:space="preserve">
     <value>接続を確認してください</value>
     <comment>Title of the no internet connection message being shown.</comment>
   </data>
-  <data name="Refresh.Content" xml:space="preserve">
+  <data name="Refresh/Content" xml:space="preserve">
     <value>リフレッシュする</value>
     <comment>This button refreshes the web page potentially after the user connected to the Internet.</comment>
   </data>

--- a/KpcUwpCore/Assets/Strings/ja-JP/Resources.resw
+++ b/KpcUwpCore/Assets/Strings/ja-JP/Resources.resw
@@ -40,4 +40,20 @@
     <value>リフレッシュする</value>
     <comment>This button refreshes the web page potentially after the user connected to the Internet.</comment>
   </data>
+  <data name="MandatoryUpdateFailedMessage/Text" xml:space="preserve">
+    <value>更新を完了できませんでした。アプリを再起動するか、ストアから再試行してください。</value>
+    <comment>Message informing users that the app failed to update and that they have a couple of options.</comment>
+  </data>
+  <data name="MandatoryUpdateInstallingMessage/Text" xml:space="preserve">
+    <value>アップデートをダウンロードとインストールしています。アプリを閉じないでください。これには数分しかかかりません。</value>
+    <comment>Message informing users that the app is currently updating and should finish shortly.</comment>
+  </data>
+  <data name="MicrosoftStore/Content" xml:space="preserve">
+    <value>Microsoftストアからアップデートする</value>
+    <comment>When updates fail to install, this button is shown to launch the Microsoft Store and retry the update.</comment>
+  </data>
+  <data name="TryLater/Content" xml:space="preserve">
+    <value>あとでもう一度お試しください</value>
+    <comment>When updates fail to install, this button is shown for the user to acknowledge that they can try to install the update later from the app. Once clicked, the app will close.</comment>
+  </data>
 </root>

--- a/KpcUwpCore/MultilingualResources/KpcUwpCore.ja-JP.xlf
+++ b/KpcUwpCore/MultilingualResources/KpcUwpCore.ja-JP.xlf
@@ -42,13 +42,13 @@
           <note from="MultilingualBuild" annotates="source" priority="2">This button refreshes the web page potentially after the user connected to the Internet.</note>
         </trans-unit>
         <trans-unit id="MandatoryUpdateFailedMessage/Text" translate="yes" xml:space="preserve">
-          <source>The update has failed to download and install this time. You can try again via the Store or later by starting the app.</source>
-          <target state="new">The update has failed to download and install this time. You can try again via the Store or later by starting the app.</target>
+          <source>The update was unable to complete. Please try again later by restarting the app or via the Store.</source>
+          <target state="new">The update was unable to complete. Please try again later by restarting the app or via the Store.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Message informing users that the app failed to update and that they have a couple of options.</note>
         </trans-unit>
         <trans-unit id="MandatoryUpdateInstallingMessage/Text" translate="yes" xml:space="preserve">
-          <source>Updates for the app are now downloading and installing. This should only take a few minutes.</source>
-          <target state="new">Updates for the app are now downloading and installing. This should only take a few minutes.</target>
+          <source>Downloading and installing updates. Please don't close the app. This should only take a few minutes.</source>
+          <target state="new">Downloading and installing updates. Please don't close the app. This should only take a few minutes.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Message informing users that the app is currently updating and should finish shortly.</note>
         </trans-unit>
         <trans-unit id="MicrosoftStore/Content" translate="yes" xml:space="preserve">

--- a/KpcUwpCore/MultilingualResources/KpcUwpCore.ja-JP.xlf
+++ b/KpcUwpCore/MultilingualResources/KpcUwpCore.ja-JP.xlf
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="ja-JP" original="KPCUWPCORE/ASSETS/STRINGS/EN-US/RESOURCES.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
-      <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.6915.0" tool-company="Microsoft" />
+      <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.6915.0" tool-company="Microsoft"/>
     </header>
     <body>
       <group id="KPCUWPCORE/ASSETS/STRINGS/EN-US/RESOURCES.RESW" datatype="resx">
@@ -43,22 +43,22 @@
         </trans-unit>
         <trans-unit id="MandatoryUpdateFailedMessage/Text" translate="yes" xml:space="preserve">
           <source>The update was unable to complete. Please try again later by restarting the app or via the Store.</source>
-          <target state="new">The update was unable to complete. Please try again later by restarting the app or via the Store.</target>
+          <target state="translated">更新を完了できませんでした。アプリを再起動するか、ストアから再試行してください。</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Message informing users that the app failed to update and that they have a couple of options.</note>
         </trans-unit>
         <trans-unit id="MandatoryUpdateInstallingMessage/Text" translate="yes" xml:space="preserve">
           <source>Downloading and installing updates. Please don't close the app. This should only take a few minutes.</source>
-          <target state="new">Downloading and installing updates. Please don't close the app. This should only take a few minutes.</target>
+          <target state="translated">アップデートをダウンロードとインストールしています。アプリを閉じないでください。これには数分しかかかりません。</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Message informing users that the app is currently updating and should finish shortly.</note>
         </trans-unit>
         <trans-unit id="MicrosoftStore/Content" translate="yes" xml:space="preserve">
           <source>Update via Microsoft Store</source>
-          <target state="new">Update via Microsoft Store</target>
+          <target state="translated">Microsoftストアからアップデートする</target>
           <note from="MultilingualBuild" annotates="source" priority="2">When updates fail to install, this button is shown to launch the Microsoft Store and retry the update.</note>
         </trans-unit>
         <trans-unit id="TryLater/Content" translate="yes" xml:space="preserve">
           <source>Try again later</source>
-          <target state="new">Try again later</target>
+          <target state="translated">あとでもう一度お試しください</target>
           <note from="MultilingualBuild" annotates="source" priority="2">When updates fail to install, this button is shown for the user to acknowledge that they can try to install the update later from the app. Once clicked, the app will close.</note>
         </trans-unit>
       </group>

--- a/KpcUwpCore/MultilingualResources/KpcUwpCore.ja-JP.xlf
+++ b/KpcUwpCore/MultilingualResources/KpcUwpCore.ja-JP.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="ja-JP" original="KPCUWPCORE/ASSETS/STRINGS/EN-US/RESOURCES.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -6,40 +6,60 @@
     </header>
     <body>
       <group id="KPCUWPCORE/ASSETS/STRINGS/EN-US/RESOURCES.RESW" datatype="resx">
-        <trans-unit id="GetUpdate.Content" translate="yes" xml:space="preserve">
+        <trans-unit id="GetUpdate/Content" translate="yes" xml:space="preserve">
           <source>Get update</source>
           <target state="translated">アップデートする</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">This button launches the Microsoft Store to get updates for the app</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">This button starts the process of downloading and installing updates for the app.</note>
         </trans-unit>
-        <trans-unit id="MandatoryUpdateAvailableMessage.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="MandatoryUpdateAvailableMessage/Text" translate="yes" xml:space="preserve">
           <source>A mandatory update is available for your app. Update now to continue using it.</source>
           <target state="translated">必須のアップデートがあります。アプリを使い続けるにはいますぐアップデートしてください。</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Message informing users that they have to update the app in order to continue using it</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">Message informing users that they have to update the app in order to continue using it.</note>
         </trans-unit>
-        <trans-unit id="MandatoryUpdateAvailableTitle.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="MandatoryUpdateAvailableTitle/Text" translate="yes" xml:space="preserve">
           <source>Update available</source>
           <target state="translated">アップデートの準備ができています</target>
-          <note from="MultilingualBuild" annotates="source" priority="2">Title of the mandatory update available message being shown</note>
+          <note from="MultilingualBuild" annotates="source" priority="2">Title of the mandatory update available message being shown.</note>
         </trans-unit>
-        <trans-unit id="CheckConnection.Content" translate="yes" xml:space="preserve">
+        <trans-unit id="CheckConnection/Content" translate="yes" xml:space="preserve">
           <source>Check connection</source>
           <target state="translated">接続を確認する</target>
           <note from="MultilingualBuild" annotates="source" priority="2">This button launches the Windows Settings app to the page that helps users connect to the Internet.</note>
         </trans-unit>
-        <trans-unit id="NoInternetConnectionMessage.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="NoInternetConnectionMessage/Text" translate="yes" xml:space="preserve">
           <source>The app can't open because you are not connected to the internet. Make sure Wi-Fi is on and try again.</source>
           <target state="translated">インターネットに接続していないため、アプリを開くことができません。 Wi-Fiがオンになっていることを確認して、もう一度お試しください。</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Message informing users that they have to connect to the internet in order to continue using the app.</note>
         </trans-unit>
-        <trans-unit id="NoInternetConnectionTitle.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="NoInternetConnectionTitle/Text" translate="yes" xml:space="preserve">
           <source>Check your connection</source>
           <target state="translated">接続を確認してください</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Title of the no internet connection message being shown.</note>
         </trans-unit>
-        <trans-unit id="Refresh.Content" translate="yes" xml:space="preserve">
+        <trans-unit id="Refresh/Content" translate="yes" xml:space="preserve">
           <source>Refresh</source>
           <target state="translated">リフレッシュする</target>
           <note from="MultilingualBuild" annotates="source" priority="2">This button refreshes the web page potentially after the user connected to the Internet.</note>
+        </trans-unit>
+        <trans-unit id="MandatoryUpdateFailedMessage/Text" translate="yes" xml:space="preserve">
+          <source>The update has failed to download and install this time. You can try again via the Store or later by starting the app.</source>
+          <target state="new">The update has failed to download and install this time. You can try again via the Store or later by starting the app.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">Message informing users that the app failed to update and that they have a couple of options.</note>
+        </trans-unit>
+        <trans-unit id="MandatoryUpdateInstallingMessage/Text" translate="yes" xml:space="preserve">
+          <source>Updates for the app are now downloading and installing. This should only take a few minutes.</source>
+          <target state="new">Updates for the app are now downloading and installing. This should only take a few minutes.</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">Message informing users that the app is currently updating and should finish shortly.</note>
+        </trans-unit>
+        <trans-unit id="MicrosoftStore/Content" translate="yes" xml:space="preserve">
+          <source>Update via Microsoft Store</source>
+          <target state="new">Update via Microsoft Store</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">When updates fail to install, this button is shown to launch the Microsoft Store and retry the update.</note>
+        </trans-unit>
+        <trans-unit id="TryLater/Content" translate="yes" xml:space="preserve">
+          <source>Try again later</source>
+          <target state="new">Try again later</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">When updates fail to install, this button is shown for the user to acknowledge that they can try to install the update later from the app. Once clicked, the app will close.</note>
         </trans-unit>
       </group>
     </body>


### PR DESCRIPTION
Users can now download and install the update straight from inside
the app without needing to jump to the Store. If automatic updates
are enabled in the Store, the process will start as soon as the
page is loaded.