### PR TITLE
Fix Patch version counter not resetting with Major and Minor bumps

### DIFF
--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -156,7 +156,7 @@
       <Version>6.2.10</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.14.5</Version>
+      <Version>4.14.7</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
       <Version>2.1.2</Version>

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -17,8 +17,8 @@ pr:
 
 variables:
   major: 2
-  minor: 1
-  patch: $[counter(variables['major'].variables['minor'].*, 0)]
+  minor: 2
+  patch: $[counter(format('{0}.{1}', variables['major'], variables['minor']), 0)]
 
 # Customise the Build.BuildNumber variable with the version of the build.
 name: '$(major).$(minor).$(patch)'


### PR DESCRIPTION
Using semantic versioning every new CI build generates a new
<Major>.<Minor>.<Patch> version. It's expected that Patch resets
when Major and/or Minor numbers are updated.

[skip ci]