### PR TITLE
Mandatory updates fixes and improvements

### DIFF
--- a/KpcUwpCore/AppUpdate/MandatoryUpdate.xaml
+++ b/KpcUwpCore/AppUpdate/MandatoryUpdate.xaml
@@ -22,7 +22,7 @@
 
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup>
-                <VisualState x:Name="UpdateAvailable">
+                <VisualState x:Name="UpdateAvailableState">
                     <VisualState.Setters>
                         <Setter
                             Target="UpdateAvailablePanel.Visibility"
@@ -35,7 +35,7 @@
                             Value="Collapsed"/>
                     </VisualState.Setters>
                 </VisualState>
-                <VisualState x:Name="UpdateInstalling">
+                <VisualState x:Name="UpdateInstallingState">
                     <VisualState.Setters>
                         <Setter
                             Target="UpdateAvailablePanel.Visibility"
@@ -48,7 +48,7 @@
                             Value="Collapsed"/>
                     </VisualState.Setters>
                 </VisualState>
-                <VisualState x:Name="UpdateFailed">
+                <VisualState x:Name="UpdateFailedState">
                     <VisualState.Setters>
                         <Setter
                             Target="UpdateAvailablePanel.Visibility"

--- a/KpcUwpCore/AppUpdate/MandatoryUpdate.xaml.cs
+++ b/KpcUwpCore/AppUpdate/MandatoryUpdate.xaml.cs
@@ -67,14 +67,21 @@ namespace KanoComputing.AppUpdate {
         private async Task DoUpdateAsync() {
             VisualStateManager.GoToState(this, this.UpdateInstallingState.Name, false);
 
-            StoreContext context = StoreContext.GetDefault();
+            try {
+                StoreContext context = StoreContext.GetDefault();
 
-            IReadOnlyList<StorePackageUpdate> updates =
-                await context.GetAppAndOptionalStorePackageUpdatesAsync();
-            StorePackageUpdateResult result =
-                await this.DownloadAndInstallAllUpdatesAsync(context, updates);
+                IReadOnlyList<StorePackageUpdate> updates =
+                    await context.GetAppAndOptionalStorePackageUpdatesAsync();
+                StorePackageUpdateResult result =
+                    await this.DownloadAndInstallAllUpdatesAsync(context, updates);
 
-            await this.HandleUpdateResultAsync(updates, result);
+                await this.HandleUpdateResultAsync(updates, result);
+
+            // If anything fails, go straight to the Failed state.
+            } catch (Exception e) {
+                VisualStateManager.GoToState(this, this.UpdateFailedState.Name, false);
+                Debug.WriteLine($"{this.GetType()}: DoUpdateAsync: Caught {e}");
+            }
         }
 
         /// <summary>

--- a/KpcUwpCore/AppUpdate/MandatoryUpdate.xaml.cs
+++ b/KpcUwpCore/AppUpdate/MandatoryUpdate.xaml.cs
@@ -42,7 +42,7 @@ namespace KanoComputing.AppUpdate {
             if (storeContext.CanSilentlyDownloadStorePackageUpdates) {
                 await this.DoUpdateAsync();
             } else {
-                VisualStateManager.GoToState(this, "UpdateAvailable", false);
+                VisualStateManager.GoToState(this, this.UpdateAvailableState.Name, false);
             }
         }
 
@@ -65,7 +65,7 @@ namespace KanoComputing.AppUpdate {
         /// Start the update process and change the UI accordingly.
         /// </summary>
         private async Task DoUpdateAsync() {
-            VisualStateManager.GoToState(this, "UpdateInstalling", false);
+            VisualStateManager.GoToState(this, this.UpdateInstallingState.Name, false);
 
             StoreContext context = StoreContext.GetDefault();
 
@@ -87,7 +87,6 @@ namespace KanoComputing.AppUpdate {
                 Debug.WriteLine($"{this.GetType()}: DownloadAndInstallAllUpdatesAsync: No updates available");
                 return null;
             }
-
             foreach (var update in updates) {
                 Debug.WriteLine($"{this.GetType()}: DownloadAndInstallAllUpdatesAsync: Update for " +
                     $"{update.Package.Id.FamilyName} to version {update.Package.Id.Version.Major}." +
@@ -127,7 +126,8 @@ namespace KanoComputing.AppUpdate {
                 IReadOnlyList<StorePackageUpdate> updates, StorePackageUpdateResult result) {
 
             if (result == null) {
-                VisualStateManager.GoToState(this, "UpdateFailed", false);
+                VisualStateManager.GoToState(this, this.UpdateFailedState.Name, false);
+                Debug.WriteLine($"{this.GetType()}: HandleUpdateResultAsync: result was null");
                 return;
             }
 
@@ -146,7 +146,7 @@ namespace KanoComputing.AppUpdate {
                 // If the update was cancelled by the user, allow them to try again.
                 case StorePackageUpdateState.Canceled: {
                     Debug.WriteLine($"{this.GetType()}: HandleUpdateResultAsync: Update cancelled");
-                    VisualStateManager.GoToState(this, "UpdateAvailable", false);
+                    VisualStateManager.GoToState(this, this.UpdateAvailableState.Name, false);
                     break;
                 }
                 // When the update failed for whatever reason, indicate this to
@@ -154,7 +154,7 @@ namespace KanoComputing.AppUpdate {
                 default: {
                     Debug.WriteLine($"{this.GetType()}: HandleUpdateResultAsync: " +
                         $"Update failed {result.OverallState}");
-                    VisualStateManager.GoToState(this, "UpdateFailed", false);
+                    VisualStateManager.GoToState(this, this.UpdateFailedState.Name, false);
 
                     IEnumerable<StorePackageUpdateStatus> failedUpdates =
                         result.StorePackageUpdateStatuses.Where(

--- a/KpcUwpCore/AppUpdate/MandatoryUpdate.xaml.cs
+++ b/KpcUwpCore/AppUpdate/MandatoryUpdate.xaml.cs
@@ -18,7 +18,6 @@ using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Navigation;
 
 
 namespace KanoComputing.AppUpdate {
@@ -32,9 +31,10 @@ namespace KanoComputing.AppUpdate {
 
         public MandatoryUpdate() {
             this.InitializeComponent();
+            this.Loaded += this.OnLoaded;
         }
 
-        protected override async void OnNavigatedTo(NavigationEventArgs args) {
+        private async void OnLoaded(object sender, RoutedEventArgs e) {
             StoreContext storeContext = StoreContext.GetDefault();
 
             // If automatic updates are enabled in Microsoft Store > Settings then


### PR DESCRIPTION
The update process itself seemed to halt as soon as the following
line was being executed:

await storeContext.RequestDownloadAndInstallStorePackageUpdatesAsync()
or
await storeContext.TrySilentDownloadAndInstallStorePackageUpdatesAsync()

Cancelling pending updates as seen in the Microsoft Store and also
downloading them prior to calling any of the above functions seems
to produce a much more reliable experience.