### PR TITLE
Use manual validation to catch MS Store deployment timeouts

### DIFF
--- a/azure-pipelines-cd.yml
+++ b/azure-pipelines-cd.yml
@@ -25,7 +25,7 @@ resources:
     type: github
     name: KanoComputing/azure-pipeline-templates
     endpoint: KanoComputing
-    ref: refs/tags/2.0.6
+    ref: refs/tags/3.1.0
 
 
 stages:

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -29,7 +29,7 @@ resources:
     type: github
     name: KanoComputing/azure-pipeline-templates
     endpoint: KanoComputing
-    ref: refs/tags/2.0.6
+    ref: refs/tags/3.1.0
 
 pool:
   vmImage: 'windows-latest'
@@ -38,7 +38,9 @@ pool:
 stages:
 - stage: Test
   jobs:
-  - template: jobs/run-visual-studio-tests.yml@templates
+  - job: Test
+    steps:
+    - template: steps/run-visual-studio-tests.yml@templates
 
 - stage: Build
   # Remove implicit dependency on previous stage and run in parallel.


### PR DESCRIPTION
[Skip CI]