### PR TITLE
Revert "Bump MSTest.TestAdapter from 2.2.3 to 2.2.5"

### DIFF
--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -172,7 +172,7 @@
       <Version>4.16.1</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>2.2.5</Version>
+      <Version>2.2.3</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
       <Version>2.2.3</Version>


### PR DESCRIPTION
Reverts KanoComputing/kpc-uwp-core#72